### PR TITLE
Query language walker test case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "laravel/framework": "^8.0 || ^9.0 || ^10.0",
         "nyholm/psr7": "^1.0",
         "phpunit/phpunit": "^9.4",
-        "refugis/doctrine-extra": "^2.1.0",
+        "refugis/doctrine-extra": "^2.1 || ^3.0",
         "refugis/elastica-odm": "2.x-dev",
         "roave/security-advisories": "dev-master",
         "solido/php-coding-standards": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,14 @@
         "refugis/elastica-odm": "2.x-dev",
         "roave/security-advisories": "dev-master",
         "solido/php-coding-standards": "dev-master",
+        "solido/query-language": "dev-master",
         "solido/security-policy-checker": "dev-master",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/cache": "^5.4 || ^6.0",
         "symfony/framework-bundle": "^5.4 || ^6.0",
-        "symfony/property-access": "^5.4 || ^6.0"
+        "symfony/property-access": "^5.4 || ^6.0",
+        "symfony/translation": "^5.4 || ^6.0",
+        "symfony/validator": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Doctrine/AbstractFakeMetadataFactory.php
+++ b/src/Doctrine/AbstractFakeMetadataFactory.php
@@ -45,6 +45,8 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
 
     /**
      * {@inheritdoc}
+     *
+     * @param class-string $className
      */
     public function getMetadataFor($className): ClassMetadata
     {
@@ -61,6 +63,8 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
 
     /**
      * {@inheritdoc}
+     *
+     * @param class-string $className
      */
     public function hasMetadataFor($className): bool
     {
@@ -73,6 +77,8 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
 
     /**
      * {@inheritdoc}
+     *
+     * @param class-string $className
      */
     public function setMetadataFor($className, $class): void
     {

--- a/src/Doctrine/AbstractFakeMetadataFactory.php
+++ b/src/Doctrine/AbstractFakeMetadataFactory.php
@@ -11,6 +11,7 @@ use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 
 use function array_values;
+use function class_exists;
 
 class AbstractFakeMetadataFactory implements ClassMetadataFactory
 {
@@ -19,7 +20,7 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
     protected RuntimeReflectionService $reflectionService;
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function __construct()
     {
@@ -36,7 +37,7 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getAllMetadata(): array
     {
@@ -44,7 +45,7 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @param class-string $className
      */
@@ -62,7 +63,7 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @param class-string $className
      */
@@ -76,7 +77,7 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @param class-string $className
      */
@@ -90,7 +91,7 @@ class AbstractFakeMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function isTransient($className): bool
     {

--- a/src/Doctrine/ORM/DummyResult.php
+++ b/src/Doctrine/ORM/DummyResult.php
@@ -29,7 +29,7 @@ final class DummyResult implements Result
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function fetchNumeric()
     {
@@ -42,7 +42,7 @@ final class DummyResult implements Result
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function fetchAssociative()
     {
@@ -50,7 +50,7 @@ final class DummyResult implements Result
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function fetchOne()
     {
@@ -64,7 +64,7 @@ final class DummyResult implements Result
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function fetchAllNumeric(): array
     {
@@ -77,7 +77,7 @@ final class DummyResult implements Result
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function fetchAllAssociative(): array
     {
@@ -90,7 +90,7 @@ final class DummyResult implements Result
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function fetchFirstColumn(): array
     {

--- a/src/Doctrine/ORM/FakeMetadataFactory.php
+++ b/src/Doctrine/ORM/FakeMetadataFactory.php
@@ -17,7 +17,7 @@ class FakeMetadataFactory extends AbstractFakeMetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setMetadataFor($className, $class): void
     {

--- a/src/Doctrine/ORM/MockPlatform.php
+++ b/src/Doctrine/ORM/MockPlatform.php
@@ -13,7 +13,7 @@ use function sprintf;
 class MockPlatform extends AbstractPlatform
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getBooleanTypeDeclarationSQL(array $column): string
     {
@@ -21,7 +21,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getIntegerTypeDeclarationSQL(array $column): string
     {
@@ -33,7 +33,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getBigIntTypeDeclarationSQL(array $column): string
     {
@@ -45,7 +45,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getSmallIntTypeDeclarationSQL(array $column): string
     {
@@ -57,7 +57,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function _getCommonIntegerTypeDeclarationSQL(array $column): string
     {
@@ -69,7 +69,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getClobTypeDeclarationSQL(array $column): string
     {
@@ -77,7 +77,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function getVarcharTypeDeclarationSQLSnippet($length, $fixed): string
     {
@@ -90,7 +90,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getBlobTypeDeclarationSQL(array $field): string
     {
@@ -103,7 +103,7 @@ class MockPlatform extends AbstractPlatform
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function getBinaryTypeDeclarationSQLSnippet($length, $fixed): string
     {

--- a/src/Doctrine/ORM/TestRepositoryFactory.php
+++ b/src/Doctrine/ORM/TestRepositoryFactory.php
@@ -20,7 +20,7 @@ final class TestRepositoryFactory implements RepositoryFactory
     private array $repositoryList = [];
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getRepository(EntityManagerInterface $entityManager, $entityName): ObjectRepository
     {

--- a/src/Elastica/FakeMetadataFactory.php
+++ b/src/Elastica/FakeMetadataFactory.php
@@ -19,14 +19,14 @@ class FakeMetadataFactory extends MetadataFactory
     private array $metadata;
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function __construct()
     {
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getAllMetadata(): array
     {
@@ -34,7 +34,7 @@ class FakeMetadataFactory extends MetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getMetadataFor($className): ClassMetadataInterface
     {
@@ -50,7 +50,7 @@ class FakeMetadataFactory extends MetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function hasMetadataFor($className): bool
     {
@@ -62,7 +62,7 @@ class FakeMetadataFactory extends MetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setMetadataFor($className, $class): void
     {
@@ -71,7 +71,7 @@ class FakeMetadataFactory extends MetadataFactory
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function isTransient($className): bool
     {

--- a/src/Laravel/KernelBrowser.php
+++ b/src/Laravel/KernelBrowser.php
@@ -32,7 +32,7 @@ class KernelBrowser extends HttpKernelBrowser
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function doRequest($request): Response
     {

--- a/src/Prophecy/Argument/Token/StringMatchesToken.php
+++ b/src/Prophecy/Argument/Token/StringMatchesToken.php
@@ -23,7 +23,7 @@ class StringMatchesToken implements TokenInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @param mixed $argument
      */

--- a/src/Prophecy/Argument/Token/StringMatchesToken.php
+++ b/src/Prophecy/Argument/Token/StringMatchesToken.php
@@ -30,7 +30,6 @@ class StringMatchesToken implements TokenInterface
     public function scoreArgument($argument)
     {
         return is_string($argument) &&
-            /** @phpstan-ignore-next-line */
             preg_match($this->value, $argument) === 1 ? 6 : false;
     }
 

--- a/src/QueryLanguage/AbstractValidationWalkerTestCase.php
+++ b/src/QueryLanguage/AbstractValidationWalkerTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\QueryLanguage;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Solido\QueryLanguage\Walker\Validation\ValidationWalkerInterface;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+use function count;
+use function interface_exists;
+use function Safe\sprintf;
+
+abstract class AbstractValidationWalkerTestCase extends TestCase
+{
+    protected ExecutionContext $context;
+    protected ValidationWalkerInterface $walker;
+
+    abstract protected function createValidationWalker(): ValidationWalkerInterface;
+
+    protected function setUp(): void
+    {
+        /** @codeCoverageIgnoreStart */
+        if (! interface_exists(ValidatorInterface::class)) {
+            throw new RuntimeException('Symfony Validator component is required to run validation walker tests. Try run composer require symfony/validator.');
+        }
+
+        if (! interface_exists(TranslatorInterface::class)) {
+            throw new RuntimeException('Symfony Translator component is required to run validation walker tests. Try run composer require symfony/translation.');
+        }
+
+        /** @codeCoverageIgnoreEnd */
+
+        $this->context = $this->createContext();
+        $this->walker = $this->createValidationWalker();
+        $this->walker->setValidationContext($this->context);
+    }
+
+    protected function createContext(): ExecutionContext
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+        $validator = $this->createMock(ValidatorInterface::class);
+
+        return new ExecutionContext($validator, null, $translator);
+    }
+
+    protected function assertNoViolation(): void
+    {
+        self::assertSame(0, $violationsCount = count($this->context->getViolations()), sprintf('0 violation expected. Got %u.', $violationsCount));
+    }
+
+    protected function buildViolation(string $message): ConstraintViolationAssertion
+    {
+        $assertion = new ConstraintViolationAssertion($this->context, $message);
+        $assertion->atPath('');
+        $assertion->setInvalidValue(null);
+
+        return $assertion;
+    }
+}

--- a/src/QueryLanguage/ConstraintViolationAssertion.php
+++ b/src/QueryLanguage/ConstraintViolationAssertion.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\QueryLanguage;
+
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+use function count;
+use function current;
+use function iterator_to_array;
+use function next;
+use function reset;
+use function sprintf;
+
+/** @internal */
+class ConstraintViolationAssertion // phpcs:ignore
+{
+    /** @var array<string, mixed> */
+    private array $parameters = [];
+    private mixed $invalidValue = 'InvalidValue';
+    private string $propertyPath = 'property.path';
+    private int|null $plural = null;
+    private string|null $code = null;
+    private mixed $cause = null;
+
+    /** @param ConstraintViolationAssertion[] $assertions */
+    public function __construct(
+        private readonly ExecutionContextInterface $context,
+        private readonly string $message,
+        private readonly Constraint|null $constraint = null,
+        private readonly array $assertions = [],
+    ) {
+    }
+
+    public function atPath(string $path): self
+    {
+        $this->propertyPath = $path;
+
+        return $this;
+    }
+
+    public function setParameter(string $key, string $value): self
+    {
+        $this->parameters[$key] = $value;
+
+        return $this;
+    }
+
+    /** @param array<string, mixed> $parameters */
+    public function setParameters(array $parameters): self
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+
+    public function setInvalidValue(mixed $invalidValue): self
+    {
+        $this->invalidValue = $invalidValue;
+
+        return $this;
+    }
+
+    public function setPlural(int $number): self
+    {
+        $this->plural = $number;
+
+        return $this;
+    }
+
+    public function setCode(string $code): self
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    public function setCause(mixed $cause): self
+    {
+        $this->cause = $cause;
+
+        return $this;
+    }
+
+    public function buildNextViolation(string $message): self
+    {
+        $assertions = $this->assertions;
+        $assertions[] = $this;
+
+        return new self($this->context, $message, $this->constraint, $assertions);
+    }
+
+    public function assertRaised(): void
+    {
+        $expected = [];
+        foreach ($this->assertions as $assertion) {
+            $expected[] = $assertion->getViolation();
+        }
+
+        $expected[] = $this->getViolation();
+
+        $violations = iterator_to_array($this->context->getViolations());
+
+        Assert::assertSame($expectedCount = count($expected), $violationsCount = count($violations), sprintf('%u violation(s) expected. Got %u.', $expectedCount, $violationsCount));
+
+        reset($violations);
+
+        foreach ($expected as $violation) {
+            Assert::assertEquals($violation, current($violations));
+            next($violations);
+        }
+    }
+
+    private function getViolation(): ConstraintViolation
+    {
+        return new ConstraintViolation(
+            $this->message,
+            $this->message,
+            $this->parameters,
+            $this->context->getRoot(),
+            $this->propertyPath,
+            $this->invalidValue,
+            $this->plural,
+            $this->code,
+            $this->constraint,
+            $this->cause,
+        );
+    }
+}

--- a/tests/QueryLanguage/AbstractValidationWalkerTestCaseTest.php
+++ b/tests/QueryLanguage/AbstractValidationWalkerTestCaseTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\Tests\QueryLanguage;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\BaseTestRunner;
+use Solido\QueryLanguage\Expression\AllExpression;
+use Solido\QueryLanguage\Expression\Comparison\LessThanExpression;
+use Solido\QueryLanguage\Expression\Literal\LiteralExpression;
+use Solido\QueryLanguage\Expression\ValueExpression;
+use Solido\QueryLanguage\Walker\Validation\ValidationWalker;
+use Solido\QueryLanguage\Walker\Validation\ValidationWalkerInterface;
+use Solido\TestUtils\QueryLanguage\AbstractValidationWalkerTestCase;
+
+class AbstractValidationWalkerTestCaseTest extends TestCase
+{
+    public function testSuccess(): void
+    {
+        $test = new SuccessTestCase();
+        $result = $test->run();
+
+        self::assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        self::assertEquals(0, $result->errorCount());
+        self::assertEquals(0, $result->failureCount());
+        self::assertEquals(0, $result->skippedCount());
+        self::assertCount(1, $result);
+    }
+
+    public function testFailure(): void
+    {
+        $test = new FailureTestCase();
+        $result = $test->run();
+
+        self::assertEquals(BaseTestRunner::STATUS_FAILURE, $test->getStatus());
+        self::assertEquals(0, $result->errorCount());
+        self::assertEquals(1, $result->failureCount());
+        self::assertEquals(0, $result->skippedCount());
+        self::assertCount(1, $result);
+    }
+
+    public function testViolationRaised(): void
+    {
+        $test = new ViolationRaisedTestCase();
+        $test->run();
+
+        self::assertEquals(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+    }
+}
+
+class ConcreteValidationWalker extends ValidationWalker
+{
+    public function walkComparison(string $operator, ValueExpression $expression): mixed
+    {
+        if ($operator !== '=') {
+            $this->addViolation('Cannot be equal', ['invalid_value' => (string) $expression]);
+        }
+
+        return parent::walkComparison($operator, $expression);
+    }
+}
+
+class SuccessTestCase extends AbstractValidationWalkerTestCase
+{
+    protected function createValidationWalker(): ValidationWalkerInterface
+    {
+        return new ConcreteValidationWalker();
+    }
+
+    public function runTest(): void
+    {
+        (new AllExpression())->dispatch($this->walker);
+        $this->assertNoViolation();
+    }
+}
+
+class FailureTestCase extends AbstractValidationWalkerTestCase
+{
+    protected function createValidationWalker(): ValidationWalkerInterface
+    {
+        return new ConcreteValidationWalker();
+    }
+
+    public function runTest(): void
+    {
+        (new LessThanExpression(LiteralExpression::create('42')))->dispatch($this->walker);
+        $this->assertNoViolation();
+    }
+}
+
+class ViolationRaisedTestCase extends AbstractValidationWalkerTestCase
+{
+    protected function createValidationWalker(): ValidationWalkerInterface
+    {
+        return new ConcreteValidationWalker();
+    }
+
+    public function runTest(): void
+    {
+        (new LessThanExpression(LiteralExpression::create('42')))->dispatch($this->walker);
+
+        $this->buildViolation('Cannot be equal')
+            ->setParameters(['invalid_value' => '42'])
+            ->assertRaised();
+    }
+}


### PR DESCRIPTION
Added `AbstractValidationWalkerTestCase` (subclass of PHPUnit `TestCase` class) containing helper methods to test validation walkers.

Example:

```php
class ExampleWalkerTest extends AbstractValidationWalkerTestCase
{
    public function testNoViolation(): void
    {
        // This test will pass only if there is no violation on the validator context
        // after the dispatch call. If a violation is added the test will fail

        (new AllExpression())->dispatch($this->walker);
        $this->assertNoViolation();
    }

    public function testViolationRaised(): void
    {
        // This test will pass only if a violation with a message equals to "My message"
        // has been raised and added to the validator context.

        (new LessThanExpression(LiteralExpression::create('42')))->dispatch($this->walker);
        $this->buildViolation('My message')
            ->assertRaised();
    }
}
```

Probably we need a more convenient way to build the expression objects and call the dispatch and could be used when testing the query walkers. Any suggestion on this?

Closes #2 