### PR TITLE
add functional request/response testing utils

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2263,7 +2263,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {
@@ -2377,16 +2376,16 @@
         },
         {
             "name": "solido/common",
-            "version": "v0.2.0",
+            "version": "v0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/solid-o/common.git",
-                "reference": "fb62fd78e710dc6e6942ddb04625a0da6b43a12b"
+                "reference": "980990ee7d135000056b86db46c7420aeeb62fd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/solid-o/common/zipball/fb62fd78e710dc6e6942ddb04625a0da6b43a12b",
-                "reference": "fb62fd78e710dc6e6942ddb04625a0da6b43a12b",
+                "url": "https://api.github.com/repos/solid-o/common/zipball/980990ee7d135000056b86db46c7420aeeb62fd3",
+                "reference": "980990ee7d135000056b86db46c7420aeeb62fd3",
                 "shasum": ""
             },
             "require": {
@@ -2438,9 +2437,9 @@
             "description": "Common classes for solido suite",
             "support": {
                 "issues": "https://github.com/solid-o/common/issues",
-                "source": "https://github.com/solid-o/common/tree/v0.2.0"
+                "source": "https://github.com/solid-o/common/tree/v0.2.1"
             },
-            "time": "2021-07-13T08:22:24+00:00"
+            "time": "2021-10-15T14:30:26+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3629,34 +3628,30 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "9cf661f4eb38f7c881cac67c75ea9b00bf97b210"
+                "reference": "8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/9cf661f4eb38f7c881cac67c75ea9b00bf97b210",
-                "reference": "9cf661f4eb38f7c881cac67c75ea9b00bf97b210",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89",
+                "reference": "8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^7.0",
-                "phpstan/phpstan": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "doctrine/coding-standard": "^8.2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "vimeo/psalm": "^4.10"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
@@ -3704,7 +3699,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.x"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -3720,7 +3715,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-29T15:13:26+00:00"
+            "time": "2021-10-22T20:16:43+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -3914,16 +3909,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.10.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "f346379c7bf39a9f46771cfd9043e0eb2dd98793"
+                "reference": "81d472f6f96b8b571cafefe8d2fef89ed9446a62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/f346379c7bf39a9f46771cfd9043e0eb2dd98793",
-                "reference": "f346379c7bf39a9f46771cfd9043e0eb2dd98793",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/81d472f6f96b8b571cafefe8d2fef89ed9446a62",
+                "reference": "81d472f6f96b8b571cafefe8d2fef89ed9446a62",
                 "shasum": ""
             },
             "require": {
@@ -3955,7 +3950,7 @@
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
                 "phpstan/phpstan": "0.12.99",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
-                "squizlabs/php_codesniffer": "3.6.0",
+                "squizlabs/php_codesniffer": "3.6.1",
                 "symfony/cache": "^4.4 || ^5.2",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
                 "vimeo/psalm": "4.10.0"
@@ -4007,9 +4002,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.10.1"
+                "source": "https://github.com/doctrine/orm/tree/2.10.2"
             },
-            "time": "2021-10-05T13:04:30+00:00"
+            "time": "2021-10-21T17:57:02+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -4915,16 +4910,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.5.6",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fac86158ffc7392e49636f77e63684c026df43b8"
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fac86158ffc7392e49636f77e63684c026df43b8",
-                "reference": "fac86158ffc7392e49636f77e63684c026df43b8",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
                 "shasum": ""
             },
             "require": {
@@ -4933,15 +4928,15 @@
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.87",
-                "phpstan/phpstan-strict-rules": "^0.12.5",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.5-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -4958,9 +4953,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/0.5.6"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
             },
-            "time": "2021-08-31T08:08:22+00:00"
+            "time": "2021-09-16T20:46:02+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -5842,16 +5837,16 @@
         },
         {
             "name": "ruflin/elastica",
-            "version": "7.1.1",
+            "version": "7.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ruflin/Elastica.git",
-                "reference": "8ecc5cdadd5bf0b69c1eb20e56246a940b43bdb7"
+                "reference": "fa4ddb1d369a86e8b6030e78c6f284d6c7b1b70f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/8ecc5cdadd5bf0b69c1eb20e56246a940b43bdb7",
-                "reference": "8ecc5cdadd5bf0b69c1eb20e56246a940b43bdb7",
+                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/fa4ddb1d369a86e8b6030e78c6f284d6c7b1b70f",
+                "reference": "fa4ddb1d369a86e8b6030e78c6f284d6c7b1b70f",
                 "shasum": ""
             },
             "require": {
@@ -5859,8 +5854,9 @@
                 "ext-json": "*",
                 "nyholm/dsn": "^2.0.0",
                 "php": "^7.2 || ^8.0",
-                "psr/log": "^1.0",
-                "symfony/deprecation-contracts": "^2.2"
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2.2",
+                "symfony/polyfill-php73": "^1.19"
             },
             "require-dev": {
                 "aws/aws-sdk-php": "^3.155",
@@ -5903,38 +5899,38 @@
             ],
             "support": {
                 "issues": "https://github.com/ruflin/Elastica/issues",
-                "source": "https://github.com/ruflin/Elastica/tree/7.1.1"
+                "source": "https://github.com/ruflin/Elastica/tree/7.1.2"
             },
-            "time": "2021-03-24T14:35:48+00:00"
+            "time": "2021-10-21T13:12:36+00:00"
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.0.15",
+            "version": "7.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80"
+                "reference": "14c324b2f2f0072933036c2f3abaeda16a56dcd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80",
-                "reference": "cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/14c324b2f2f0072933036c2f3abaeda16a56dcd3",
+                "reference": "14c324b2f2f0072933036c2f3abaeda16a56dcd3",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "0.5.1 - 0.5.6",
-                "squizlabs/php_codesniffer": "^3.6.0"
+                "phpstan/phpdoc-parser": "^1.0.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
             },
             "require-dev": {
                 "phing/phing": "2.17.0",
                 "php-parallel-lint/php-parallel-lint": "1.3.1",
-                "phpstan/phpstan": "0.12.98",
+                "phpstan/phpstan": "0.12.99",
                 "phpstan/phpstan-deprecation-rules": "0.12.6",
                 "phpstan/phpstan-phpunit": "0.12.22",
                 "phpstan/phpstan-strict-rules": "0.12.11",
-                "phpunit/phpunit": "7.5.20|8.5.5|9.5.9"
+                "phpunit/phpunit": "7.5.20|8.5.5|9.5.10"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5954,7 +5950,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.15"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.16"
             },
             "funding": [
                 {
@@ -5966,7 +5962,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-09T10:29:09+00:00"
+            "time": "2021-10-22T06:56:51+00:00"
         },
         {
             "name": "solido/php-coding-standards",

--- a/src/Constraint/ResponseHeaderSame.php
+++ b/src/Constraint/ResponseHeaderSame.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\Constraint;
+
+use Solido\Common\Exception\UnsupportedResponseObjectException;
+
+use function json_encode;
+use function Safe\sprintf;
+
+use const JSON_THROW_ON_ERROR;
+
+final class ResponseHeaderSame extends ResponseConstraint
+{
+    private string $header;
+    private string $value;
+
+    public function __construct(string $header, string $value)
+    {
+        $this->header = $header;
+        $this->value = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function matches($other): bool
+    {
+        try {
+            $adapter = self::getResponseAdapter($other);
+        } catch (UnsupportedResponseObjectException $e) {
+            return false;
+        }
+
+        $header = $adapter->getHeader($this->header)[0] ?? null;
+
+        return $header === $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function failureDescription($other): string
+    {
+        try {
+            $adapter = self::getResponseAdapter($other);
+        } catch (UnsupportedResponseObjectException $e) {
+            return sprintf('%s is a response object', $this->exporter()->shortenedExport($other));
+        }
+
+        $header = $adapter->getHeader($this->header)[0] ?? null;
+
+        return sprintf(
+            '%s has header %s with value %s (%s)',
+            $this->exporter()->shortenedExport($other),
+            json_encode($this->header, JSON_THROW_ON_ERROR),
+            json_encode($this->value, JSON_THROW_ON_ERROR),
+            $header === null ? 'header missing' : 'actual value: ' . json_encode($header, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            'has header %s with value %s',
+            json_encode($this->header, JSON_THROW_ON_ERROR),
+            json_encode($this->value, JSON_THROW_ON_ERROR)
+        );
+    }
+}

--- a/src/Constraint/ResponseSubset.php
+++ b/src/Constraint/ResponseSubset.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\Constraint;
+
+use ArrayObject;
+use Solido\Common\Exception\UnsupportedResponseObjectException;
+use Solido\Common\ResponseAdapter\ResponseAdapterInterface;
+use Traversable;
+
+use function is_array;
+use function is_string;
+use function iterator_to_array;
+use function json_decode;
+use function json_last_error;
+use function Safe\array_replace_recursive;
+use function Safe\preg_match;
+use function Safe\sprintf;
+use function str_contains;
+
+use const JSON_ERROR_NONE;
+use const JSON_THROW_ON_ERROR;
+
+final class ResponseSubset extends ResponseConstraint
+{
+    /** @var string|array<string|int, mixed>|object */
+    private $subset;
+
+    /**
+     * @param string|array<string|int, mixed>|object $subset
+     */
+    public function __construct($subset)
+    {
+        $this->subset = $subset;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function matches($other): bool
+    {
+        try {
+            $adapter = self::getResponseAdapter($other);
+        } catch (UnsupportedResponseObjectException $e) {
+            return false;
+        }
+
+        if (! $this->isJson($adapter)) {
+            return is_string($this->subset) && str_contains($adapter->getContent(), $this->subset);
+        }
+
+        $other = json_decode($adapter->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $this->subset = $this->toArray($this->subset);
+
+        $patched = array_replace_recursive($other, $this->subset);
+
+        return $other === $patched;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function failureDescription($other): string
+    {
+        try {
+            self::getResponseAdapter($other);
+        } catch (UnsupportedResponseObjectException $e) {
+            return sprintf('%s is a response object', $this->exporter()->shortenedExport($other));
+        }
+
+        return sprintf(
+            '%s contains subset %s',
+            $this->exporter()->shortenedExport($other),
+            $this->exporter()->export($this->subset),
+        );
+    }
+
+    public function toString(): string
+    {
+        return sprintf(
+            'contains subset %s',
+            $this->exporter()->export($this->subset),
+        );
+    }
+
+    private function isJson(ResponseAdapterInterface $response): bool
+    {
+        if (! preg_match('/application\/json/', $response->getContentType())) {
+            return false;
+        }
+
+        $content = $response->getContent();
+
+        /** @phpstan-ignore-next-line */
+        @json_decode($content);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    /**
+     * @param mixed $other
+     *
+     * @return array<string|int, mixed>
+     */
+    private function toArray($other): array
+    {
+        if (is_array($other)) {
+            return $other;
+        }
+
+        if ($other instanceof ArrayObject) {
+            return $other->getArrayCopy();
+        }
+
+        if ($other instanceof Traversable) {
+            return iterator_to_array($other);
+        }
+
+        return (array) $other;
+    }
+}

--- a/src/Functional/Request.php
+++ b/src/Functional/Request.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\Functional;
+
+use Psr\Http\Message\UploadedFileInterface;
+
+abstract class Request
+{
+    protected string $method;
+    protected string $path;
+
+    /** @var array<string, string[]> */
+    protected array $headers;
+    /** @var mixed */
+    protected $content;
+    /** @var array<string, UploadedFileInterface> */
+    protected array $files;
+
+    public function __construct()
+    {
+        $this->method = 'GET';
+        $this->path = '/';
+        $this->headers = [];
+        $this->content = null;
+        $this->files = [];
+    }
+
+    public function withPath(string $path): self
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function withMethod(string $method): self
+    {
+        $this->method = $method;
+
+        return $this;
+    }
+
+    /**
+     * @param string|string[] $value
+     */
+    public function withHeader(string $name, $value): self
+    {
+        $this->headers[$name] = (array) $value;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $content
+     */
+    public function withContent($content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function withFile(string $name, UploadedFileInterface $file): self
+    {
+        $this->files[$name] = $file;
+
+        return $this;
+    }
+
+    /**
+     * Create a Response object to apply constraints onto.
+     */
+    abstract public function expectResponse(): Response;
+}

--- a/src/Functional/Response.php
+++ b/src/Functional/Response.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\Functional;
+
+use PHPUnit\Framework\Assert;
+use Solido\TestUtils\Constraint\JsonResponse;
+use Solido\TestUtils\Constraint\ResponseHasHeaders;
+use Solido\TestUtils\Constraint\ResponseHeaderSame;
+use Solido\TestUtils\Constraint\ResponseStatusCode;
+use Solido\TestUtils\Constraint\ResponseSubset;
+
+use function array_keys;
+use function range;
+
+class Response
+{
+    private const STATUS_CODE_CLASS_INFORMATIONAL = 100;
+    private const STATUS_CODE_CLASS_SUCCESS = 200;
+    private const STATUS_CODE_CLASS_REDIRECTION = 300;
+    private const STATUS_CODE_CLASS_CLIENT_ERROR = 400;
+    private const STATUS_CODE_CLASS_SERVER_ERROR = 500;
+
+    private const TYPE_JSON = 'json';
+
+    /** @var callable(): object */
+    private $performer;
+    private bool $checked = false;
+
+    private ?int $statusCode;
+    private ?int $statusCodeClass;
+
+    /** @var array<string, string|null> */
+    private array $headers;
+    private ?string $type;
+
+    /** @var string|array<(string|int), mixed>|null */
+    private $minimumSubset;
+
+    public function __construct(callable $performer)
+    {
+        $this->performer = $performer;
+        $this->statusCode = null;
+        $this->statusCodeClass = null;
+        $this->headers = [];
+        $this->type = null;
+        $this->minimumSubset = null;
+    }
+
+    public function __destruct()
+    {
+        $this->check();
+    }
+
+    public function shouldHaveStatusCode(int $statusCode): self
+    {
+        $this->statusCode = $statusCode;
+        $this->statusCodeClass = null;
+
+        return $this;
+    }
+
+    public function shouldHaveInformationalStatus(): self
+    {
+        $this->statusCodeClass = self::STATUS_CODE_CLASS_INFORMATIONAL;
+        $this->statusCode = null;
+
+        return $this;
+    }
+
+    public function shouldHaveSuccessStatus(): self
+    {
+        $this->statusCodeClass = self::STATUS_CODE_CLASS_SUCCESS;
+        $this->statusCode = null;
+
+        return $this;
+    }
+
+    public function shouldHaveRedirectionStatus(): self
+    {
+        $this->statusCodeClass = self::STATUS_CODE_CLASS_REDIRECTION;
+        $this->statusCode = null;
+
+        return $this;
+    }
+
+    public function shouldHaveClientErrorStatus(): self
+    {
+        $this->statusCodeClass = self::STATUS_CODE_CLASS_CLIENT_ERROR;
+        $this->statusCode = null;
+
+        return $this;
+    }
+
+    public function shouldHaveServerErrorStatus(): self
+    {
+        $this->statusCodeClass = self::STATUS_CODE_CLASS_SERVER_ERROR;
+        $this->statusCode = null;
+
+        return $this;
+    }
+
+    public function shouldHaveHeader(string $name, ?string $value = null): self
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    public function shouldBeJson(): self
+    {
+        $this->type = self::TYPE_JSON;
+
+        return $this;
+    }
+
+    /**
+     * @param string | array<string|int, mixed> $content
+     */
+    public function shouldContainAtLeast($content): self
+    {
+        $this->minimumSubset = $content;
+
+        return $this;
+    }
+
+    public function check(): void
+    {
+        if ($this->checked) {
+            return;
+        }
+
+        $this->checked = true;
+        $response = ($this->performer)();
+
+        if ($this->statusCode !== null) {
+            Assert::assertThat($response, new ResponseStatusCode($this->statusCode));
+        }
+
+        if ($this->statusCodeClass !== null) {
+            Assert::assertThat($response, new ResponseStatusCode(...range($this->statusCodeClass, $this->statusCodeClass + 99)));
+        }
+
+        if (! empty($this->headers)) {
+            Assert::assertThat($response, new ResponseHasHeaders(array_keys($this->headers)));
+            foreach ($this->headers as $name => $value) {
+                if ($value === null) {
+                    continue;
+                }
+
+                Assert::assertThat($response, new ResponseHeaderSame($name, $value));
+            }
+        }
+
+        if ($this->type === self::TYPE_JSON) {
+            Assert::assertThat($response, new JsonResponse());
+        }
+
+        if ($this->minimumSubset === null) {
+            return;
+        }
+
+        Assert::assertThat($response, new ResponseSubset($this->minimumSubset));
+    }
+}

--- a/src/HttpTestCaseInterface.php
+++ b/src/HttpTestCaseInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+
+interface HttpTestCaseInterface
+{
+    /**
+     * Performs a request.
+     *
+     * @param array<string, mixed>|string $requestData
+     * @param array<string, string> $additionalHeaders
+     * @param UploadedFile[] $files
+     * @param array<string, string> $server
+     */
+    public static function request(
+        string $url,
+        string $method,
+        $requestData = null,
+        array $additionalHeaders = [],
+        array $files = [],
+        array $server = []
+    ): Response;
+}

--- a/src/ResponseStatusTrait.php
+++ b/src/ResponseStatusTrait.php
@@ -14,8 +14,7 @@ trait ResponseStatusTrait
 {
     public static function assertResponseIs(int $expectedCode, string $message = ''): void
     {
-        $response = static::getResponse();
-        self::assertThat($response, new ResponseStatusCode($expectedCode), $message);
+        self::assertThat(static::getResponse(), new ResponseStatusCode($expectedCode), $message);
     }
 
     public static function assertResponseIsOk(string $message = ''): void

--- a/src/Symfony/Request.php
+++ b/src/Symfony/Request.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\Symfony;
+
+use Solido\TestUtils\Functional\Request as BaseRequest;
+use Solido\TestUtils\Functional\Response;
+use Solido\TestUtils\HttpTestCaseInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+use function array_map;
+use function Safe\fclose;
+use function Safe\fopen;
+use function Safe\fwrite;
+use function Safe\tempnam;
+use function sys_get_temp_dir;
+
+class Request extends BaseRequest
+{
+    private HttpTestCaseInterface $testCase;
+    private Response $response;
+
+    public function __construct(HttpTestCaseInterface $testCase)
+    {
+        parent::__construct();
+
+        $this->testCase = $testCase;
+    }
+
+    public function __destruct()
+    {
+        if (isset($this->response)) {
+            return;
+        }
+
+        $this->expectResponse()->shouldHaveSuccessStatus()->check();
+    }
+
+    public function expectResponse(): Response
+    {
+        return $this->response ?? ($this->response = new Response(fn () => $this->perform()));
+    }
+
+    protected function perform(): HttpResponse
+    {
+        $files = [];
+        foreach ($this->files as $name => $file) {
+            $tmpFile = tempnam(sys_get_temp_dir(), 'upload_' . $name);
+            $handle = fopen($tmpFile, 'wb+');
+            fwrite($handle, $file->getStream()->getContents());
+            fclose($handle);
+
+            $files[] = new UploadedFile($tmpFile, $file->getClientFilename() ?? 'file', $file->getClientMediaType(), $file->getError(), true);
+        }
+
+        $headers = array_map(static fn (array $header) => $header[0], $this->headers);
+
+        return $this->testCase::request($this->path, $this->method, $this->content, $headers, $files);
+    }
+}

--- a/tests/Constraint/ResponseHeaderSameTest.php
+++ b/tests/Constraint/ResponseHeaderSameTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\Tests\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Solido\TestUtils\Constraint\ResponseHeaderSame;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResponseHeaderSameTest extends TestCase
+{
+    /**
+     * @dataProvider matchesProvider
+     */
+    public function testMatches($expected, string $name, string $value, $response, string $message = ''): void
+    {
+        $constraint = new ResponseHeaderSame($name, $value);
+        if (! $expected) {
+            $this->expectException(ExpectationFailedException::class);
+            $this->expectExceptionMessage($message);
+        } else {
+            $this->addToAssertionCount(1);
+        }
+
+        $constraint->evaluate($response);
+    }
+
+    public function matchesProvider(): iterable
+    {
+        yield [false, 'Accept', '', null, 'Failed asserting that null is a response object.'];
+        yield [false, 'Accept', '', true, 'Failed asserting that true is a response object.'];
+        yield [false, 'Accept', '', '', "Failed asserting that '' is a response object."];
+        yield [false, 'Content-Length', '30', new Response(), 'Failed asserting that Symfony\Component\HttpFoundation\Response Object (...) has header "Content-Length" with value "30" (header missing).'];
+        yield [false, 'Content-Encoding', '30', new Response('', 200, ['Content-Encoding' => 'gzip']), 'Failed asserting that Symfony\Component\HttpFoundation\Response Object (...) has header "Content-Encoding" with value "30" (actual value: "gzip").'];
+        yield [true, 'Content-Length', '7442', new Response('', 200, ['Content-Length' => '7442'])];
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseHeaderSame('Content-Type', '42');
+        self::assertEquals('has header "Content-Type" with value "42"', $constraint->toString());
+    }
+}

--- a/tests/Constraint/ResponseSubsetTest.php
+++ b/tests/Constraint/ResponseSubsetTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\TestUtils\Tests\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Solido\TestUtils\Constraint\ResponseHeaderSame;
+use Solido\TestUtils\Constraint\ResponseSubset;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResponseSubsetTest extends TestCase
+{
+    /**
+     * @dataProvider matchesProvider
+     */
+    public function testMatches($expected, $subset, $response, string $message = ''): void
+    {
+        $constraint = new ResponseSubset($subset);
+        if (! $expected) {
+            $this->expectException(ExpectationFailedException::class);
+            $this->expectExceptionMessage($message);
+        } else {
+            $this->addToAssertionCount(1);
+        }
+
+        $constraint->evaluate($response);
+    }
+
+    public function matchesProvider(): iterable
+    {
+        yield 'array subset and json response, strict not matching' => [
+            'expected' => false,
+            'subset' => ['bar' => 0],
+            'response' => new JsonResponse(['foo' => '', 'bar' => '0']),
+            'message' => 'Failed asserting that Symfony\Component\HttpFoundation\JsonResponse Object (...) contains subset Array &0 (
+    \'bar\' => 0
+).'
+        ];
+
+        yield 'array subset and json response, matching' => [
+            'expected' => true,
+            'subset' => ['bar' => '0'],
+            'response' => new JsonResponse(['foo' => '', 'bar' => '0']),
+            'message' => ''
+        ];
+
+        yield 'array subset and json response, matching recursive' => [
+            'expected' => true,
+            'subset' => ['bar' => ['barbar' => '1']],
+            'response' => new JsonResponse(['foo' => '', 'bar' => ['foobar' => '0', 'barbar' => '1']]),
+            'message' => ''
+        ];
+
+        yield 'string subset and string response, not matching' => [
+            'expected' => false,
+            'subset' => 'great jupiter!',
+            'response' => new Response('This is a great foo day!'),
+            'message' => 'Failed asserting that Symfony\Component\HttpFoundation\Response Object (...) contains subset \'great jupiter!\'.'
+        ];
+
+        yield 'string subset and string response, matching' => [
+            'expected' => true,
+            'subset' => 'great foo',
+            'response' => new Response('This is a great foo day!'),
+            'message' => ''
+        ];
+    }
+
+    public function testToString(): void
+    {
+        $constraint = new ResponseSubset(['bar' => 0]);
+        self::assertEquals("contains subset Array &0 (\n    'bar' => 0\n)", $constraint->toString());
+    }
+}

--- a/tests/Symfony/WebFunctionalTestTraitTest.php
+++ b/tests/Symfony/WebFunctionalTestTraitTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Solido\TestUtils\Tests\Symfony;
 
+use Solido\TestUtils\HttpTestCaseInterface;
 use Solido\TestUtils\Symfony\FunctionalTestTrait;
 use Solido\TestUtils\Tests\fixtures\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class WebFunctionalTestTraitTest extends WebTestCase
+class WebFunctionalTestTraitTest extends WebTestCase implements HttpTestCaseInterface
 {
     use FunctionalTestTrait;
 


### PR DESCRIPTION
Add request/response functional testing utils.

Example:

```php
use Solido\TestUtils\HttpTestCaseInterface;
use Solido\TestUtils\Symfony\FunctionalTestTrait;
use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;

class FooTest extends WebTestCase implements HttpTestCaseInterface
{
    use FunctionalTestTrait;

    public function testExample(): void
    {
        $this->buildRequest()
            ->withMethod('POST')
            ->withPath('/path/of/the/request')
            ->withHeader('Accept', 'application/json')
            ->withContent(['json' => 'convert'])
            ->expectRespose()
            ->shouldHaveStatusCode(200)
            ->shouldHaveHeader('Content-Type', 'application/json')
            ->shouldBeJson()
            ->shouldContainAtLeast(['id' => 42, 'foo' => 'bar']);
    }
}

```

This will route the request prepared before the `expectResponse` call to the kernel and perform the subsequent checks when the test method exits.
In particular, `shouldContainAtLeast` will check the response content (converting it from json if needed) and verify it contains the provided subset array recursively. If the response does not contain a JSON and the argument is a string, the constraint will check if the provided string is contained in the response body.

Extra:

- add `ResponseHeaderSame` constraint
- add `ResponseSubset` constraint